### PR TITLE
Use promises for fetching redirect views

### DIFF
--- a/ApiHelper.php
+++ b/ApiHelper.php
@@ -158,7 +158,7 @@ class ApiHelper {
 				} else {
 					$result = $response['value'];
 					$result = json_decode( $result->getBody()->getContents(), true );
-					if ( $result ) {
+					if ( $result && isset( $result['items'][0]['views'] ) ) {
 						$results[$page] += (int)$result['items'][0]['views'];
 					}
 				}


### PR DESCRIPTION
This might seem like a small optimization but in a few tests I ran, a lot pages seem to have redirects. 
With redirect views, we're fetching almost 3x the number of requests for each project than before. 