### PR TITLE
Improve performance by using replicas and increase API request rate

### DIFF
--- a/PageviewsRepository.php
+++ b/PageviewsRepository.php
@@ -1,0 +1,161 @@
+<?php
+declare( strict_types=1 );
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use function GuzzleHttp\Promise\settle;
+use GuzzleRetry\GuzzleRetryMiddleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A PageviewsRepository handles interaction with the Wikimedia Pageviews API.
+ * Much of this code was borrowed from wikimedia/eventmetrics, licensed under GPL-3.0-or-later.
+ * Requests that get a 429 and 503 response are automatically retried by
+ * caseyamcl/guzzle_retry_middleware, waiting a exponentially longer amount of time based on
+ * the number of retries.
+ */
+class PageviewsRepository {
+	private const REQUEST_TIMEOUT = 3;
+	private const CONNECT_TIMEOUT = 1.5;
+
+	/** @var int This defines the delay between *groups* of requests. */
+	private const REQUEST_DELAY = 500;
+
+	/** @var string Base URL for the REST endpoint. */
+	protected $endpointUrl = 'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article';
+
+	/** @var string The domain of the project. */
+	protected $domain;
+
+	/** @var Client The GuzzleHttp client. */
+	private $client;
+
+	public function __construct( string $domain ) {
+		$this->domain = $domain;
+		$stack = HandlerStack::create();
+		$stack->push( GuzzleRetryMiddleware::factory() );
+
+		/**
+		 * Listen for retry events and log them.
+		 * @param int $attemptNumber
+		 * @param float $delay
+		 * @param RequestInterface $request
+		 * @param array $options
+		 * @param ResponseInterface|null $response
+		 */
+		$retryNotifier = function ( $attemptNumber, $delay, $request, $options, $response ): void {
+			$msg = sprintf(
+			    "Attempt #%s to retry request to %s. Server responded with %s. Waiting %s seconds.",
+				$attemptNumber,
+				$request->getUri()->getPath(),
+				$response->getStatusCode(),
+				number_format( $delay, 2 )
+			);
+			wfLogToFile( $msg );
+		};
+
+		$this->client = new Client( [
+			'timeout' => self::REQUEST_TIMEOUT,
+			'connect_timeout' => self::CONNECT_TIMEOUT,
+			'delay' => self::REQUEST_DELAY,
+			'handler' => $stack,
+			'retry_on_timeout' => true,
+			'on_retry_callback' => $retryNotifier,
+		] );
+	}
+
+	/**
+	 * Get the combined pageviews of the given articles.
+	 * @param string[][] $batch Keys are target name, values are arrays of target + redirects.
+	 * @param string $start
+	 * @param string $end
+	 * @return array
+	 */
+	public function getPageviews( array $batch, string $start, string $end ) : array {
+		$targetTitles = array_keys( $batch );
+
+		// Set up pageviews array with zero values.
+		$pageviews = [];
+		foreach ( $targetTitles as $targetPage ) {
+			$pageviews[$targetPage] = 0;
+		}
+
+		// All page titles to be processed with this batch.
+		$titles = array_unique( array_merge( ...array_values( $batch ) ) );
+
+		// Queue promises.
+		$promises = [];
+		foreach ( $titles as $title ) {
+			$promises[] = $this->get( $title, $start, $end );
+		}
+
+		// Make all requests at self::REQUEST_DELAY (ms) intervals.
+		$responses = settle( $promises )->wait();
+
+		foreach ( $responses as $response ) {
+			if ( 'fulfilled' !== $response['state'] ) {
+				/** @var GuzzleHttp\Exception\ClientException $reason */
+				$reason = $response['reason'];
+
+				if ( 404 == $reason->getCode() ) {
+					// No data available; okay to omit this page from the report.
+					continue;
+				}
+
+				// Do nothing, API didn't have data most likely.
+				// Note that 429s are captured by the retry handler.
+				continue;
+			}
+
+			/** @var Response $value */
+			$value = $response['value'];
+			$result = json_decode( $value->getBody()->getContents(), true );
+			[ $page, $count ] = $this->processResponse( $result );
+
+			foreach ( $targetTitles as $index => $targetPage ) {
+				if ( in_array( $page, $batch[$targetPage] ) ) {
+					$pageviews[$targetPage] += $count;
+					break;
+				}
+			}
+		}
+
+		return $pageviews;
+	}
+
+	/**
+	 * Given a Mediawiki article and a date range, returns a daily timeseries of its pageviews.
+	 * @param string $article Page title with underscores. Will be URL-encoded.
+	 * @param string $start
+	 * @param string $end
+	 * @return PromiseInterface
+	 */
+	public function get( string $article, string $start, string $end ) : PromiseInterface {
+		$article = rawurlencode( $article );
+		$url = "{$this->endpointUrl}/{$this->domain}/all-access/user/$article/monthly/$start/$end";
+		return $this->client->getAsync( $url );
+	}
+
+	/**
+	 * Parse the given Pageviews API response, returning the sum, and average if requested.
+	 * @param array[][] $response
+	 * @return array [Article name, number of pageviews] or null if there were no pageviews.
+	 */
+	private function processResponse( array $response ) : ?array {
+		if ( empty( $response['items'] ) ) {
+			return null;
+		}
+
+		$article = null;
+		$pageviews = 0;
+		foreach ( array_reverse( $response['items'] ) as $item ) {
+			$pageviews += (int)$item['views'];
+			$article = str_replace( '_', ' ', $item['article'] );
+		}
+
+		return [ $article, $pageviews ];
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
 		"krinkle/intuition": "^1.2.0",
 		"twig/twig": "^1.0",
 		"symfony/yaml": "^3.4",
-		"ext-json": "*"
+		"ext-json": "*",
+      	"ext-mysqli": "*",
+		"caseyamcl/guzzle_retry_middleware": "^2.2"
     },
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "^0.7",
@@ -20,7 +22,8 @@
 		"files": [
 			"Logger.php",
 			"ApiHelper.php",
-			"ReportUpdater.php"
+			"ReportUpdater.php",
+			"PageviewsRepository.php"
 		]
 	},
 	"autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdee02dbfe70dd322781d65077cf1d86",
+    "content-hash": "c095d1e5f2cc79b6aeea2262815969e3",
     "packages": [
         {
             "name": "addwiki/mediawiki-api-base",
@@ -59,6 +59,65 @@
                 "mediawiki"
             ],
             "time": "2017-11-02T10:53:36+00:00"
+        },
+        {
+            "name": "caseyamcl/guzzle_retry_middleware",
+            "version": "v2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/caseyamcl/guzzle_retry_middleware.git",
+                "reference": "6f4b6950d5f6f848c847bd516a9f4ceeb4332287"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/caseyamcl/guzzle_retry_middleware/zipball/6f4b6950d5f6f848c847bd516a9f4ceeb4332287",
+                "reference": "6f4b6950d5f6f848c847bd516a9f4ceeb4332287",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3",
+                "php": "~5.5|~7.0"
+            },
+            "require-dev": {
+                "nesbot/carbon": "~1.22",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleRetry\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Casey McLaughlin",
+                    "email": "caseyamcl@gmail.com",
+                    "homepage": "https://caseymclaughlin.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Guzzle middleware that handles HTTP Retry-After middleware",
+            "homepage": "https://github.com/caseyamcl/guzzle_retry_middleware",
+            "keywords": [
+                "Guzzle",
+                "back-off",
+                "caseyamcl",
+                "guzzle_retry_middleware",
+                "middleware",
+                "retry",
+                "retry-after"
+            ],
+            "time": "2018-06-06T18:20:12+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -178,33 +237,37 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.5.2",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115"
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
                 "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5"
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
+                "ext-zlib": "*",
                 "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -241,7 +304,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2018-12-04T20:46:45+00:00"
+            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "krinkle/intuition",
@@ -385,24 +448,24 @@
         },
         {
             "name": "ralouphie/getallheaders",
-            "version": "2.0.5",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.7.0",
-                "satooshi/php-coveralls": ">=1.0"
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
             },
             "type": "library",
             "autoload": {
@@ -421,7 +484,7 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
-            "time": "2016-02-11T07:05:27+00:00"
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -483,7 +546,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.26",
+            "version": "v3.4.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -542,16 +605,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.39.1",
+            "version": "v1.42.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "23e7b6f0cfa1d7ba3de69f30d8e05cf957412fec"
+                "reference": "21707d6ebd05476854805e4f91b836531941bcd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/23e7b6f0cfa1d7ba3de69f30d8e05cf957412fec",
-                "reference": "23e7b6f0cfa1d7ba3de69f30d8e05cf957412fec",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/21707d6ebd05476854805e4f91b836531941bcd4",
+                "reference": "21707d6ebd05476854805e4f91b836531941bcd4",
                 "shasum": ""
             },
             "require": {
@@ -561,12 +624,12 @@
             "require-dev": {
                 "psr/container": "^1.0",
                 "symfony/debug": "^2.7",
-                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.39-dev"
+                    "dev-master": "1.42-dev"
                 }
             },
             "autoload": {
@@ -604,7 +667,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-04-16T17:12:57+00:00"
+            "time": "2019-06-18T15:35:16+00:00"
         }
     ],
     "packages-dev": [
@@ -803,16 +866,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -850,7 +913,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -901,16 +964,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
@@ -931,8 +994,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -960,7 +1023,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1336,6 +1399,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {
@@ -1847,7 +1911,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.2",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mysqli": "*"
     },
     "platform-dev": []
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,4 +7,7 @@
     <exclude-pattern>vendor/</exclude-pattern>
     <exclude-pattern>cache/</exclude-pattern>
     <exclude-pattern>.git</exclude-pattern>
+    <rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+        <exclude name="MediaWiki.ControlStructures.AssignmentInControlStructures.AssignmentInControlStructures" />
+    </rule>
 </ruleset>

--- a/views/report.wikitext.twig
+++ b/views/report.wikitext.twig
@@ -21,8 +21,8 @@
 {% for title, data in pages %}
 | {{ loop.index }}
 | [[{{ title }}]]
-| [https://tools.wmflabs.org/redirectviews/?project={{ wiki }}.org&amp;start={{ start|date('Y-m-d') }}&amp;end={{ end|date('Y-m-d') }}&amp;page={{ title|replace({' ': '_'}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.views }}}}]
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.avgViews }}}}
+| [https://tools.wmflabs.org/redirectviews/?project={{ wiki }}.org&amp;start={{ start|date('Y-m-d') }}&amp;end={{ end|date('Y-m-d') }}&amp;page={{ title|replace({' ': '_'}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.pageviews }}}}]
+| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ data.avgPageviews }}}}
 | style="text-align:center; white-space:nowrap; font-weight:bold; background:{{ assessments.class[data.class].color }}" | [[:{{ assessments.class[data.class].category }}|{{ data.class }}]]
 | style="text-align:center; white-space:nowrap; font-weight:bold; background:{{ assessments.importance[data.importance].color }}" | [[:{{ assessments.importance[data.importance].category }}|{{ data.importance }}]]
 |-


### PR DESCRIPTION
Use the replicas to fetch WikiProject members and their assessments all
in one query. We then fetch() through one by one to limit memory
consumption.

Make a higher number of asynchronous requests to the pageviews API. We
end up making requests in "batches", that may actually exceed 100
req/sec, but we use caseyamcl/guzzle_retry_middleware to automatically
retry requests denied by throttling, waiting for the amount of time
given by the Retry-After header.

Bug: T227713